### PR TITLE
feat(assignment): implement assignment timeout logic and related tests

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contractevent, contractimpl, contracttype, token, Address, BytesN, Env, String,
 };
 
+pub const ASSIGNMENT_TIMEOUT_SECONDS: u64 = 7 * 24 * 60 * 60;
+
 mod registry {
     use soroban_sdk::{contractclient, contracttype, Address, Env, String};
 
@@ -59,6 +61,7 @@ pub enum DataKey {
     Admin,
     IsPaused,
     PlatformFee,
+    AssignmentTime(u64),
 }
 
 #[contractevent]
@@ -69,6 +72,12 @@ pub struct JobCreated {
 
 #[contractevent]
 pub struct JobAssigned {
+    pub id: u64,
+    pub artisan: Address,
+}
+
+#[contractevent]
+pub struct AssignmentTimedOut {
     pub id: u64,
     pub artisan: Address,
 }
@@ -272,9 +281,62 @@ impl MarketContract {
         env.storage().persistent().set(&DataKey::Job(job_id), &job);
         env.storage()
             .persistent()
+            .set(&DataKey::AssignmentTime(job_id), &env.ledger().timestamp());
+        env.storage()
+            .persistent()
             .extend_ttl(&DataKey::Job(job_id), 100_000, 500_000);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::AssignmentTime(job_id), 100_000, 500_000);
 
         JobAssigned {
+            id: job_id,
+            artisan,
+        }
+        .publish(&env);
+    }
+
+    pub fn reopen_timed_out_assignment(env: Env, finder: Address, job_id: u64) {
+        assert!(!is_paused(&env), "Contract Paused");
+        finder.require_auth();
+
+        let mut job: Job = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Job(job_id))
+            .expect("Job not found");
+
+        if job.finder != finder {
+            panic!("Not job owner");
+        }
+        if job.status != JobStatus::Assigned {
+            panic!("Job is not assigned");
+        }
+
+        let assigned_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AssignmentTime(job_id))
+            .expect("Assignment time not found");
+        let timeout_at = assigned_at
+            .checked_add(ASSIGNMENT_TIMEOUT_SECONDS)
+            .expect("Assignment timeout overflow");
+        if env.ledger().timestamp() < timeout_at {
+            panic!("Assignment has not timed out");
+        }
+
+        let artisan = job.artisan.take().expect("Job has no assigned artisan");
+        job.status = JobStatus::Open;
+
+        env.storage().persistent().set(&DataKey::Job(job_id), &job);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::AssignmentTime(job_id));
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Job(job_id), 100_000, 500_000);
+
+        AssignmentTimedOut {
             id: job_id,
             artisan,
         }
@@ -343,6 +405,9 @@ impl MarketContract {
         job.start_time = env.ledger().timestamp();
 
         env.storage().persistent().set(&DataKey::Job(job_id), &job);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::AssignmentTime(job_id));
         env.storage()
             .persistent()
             .extend_ttl(&DataKey::Job(job_id), 100_000, 500_000);

--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -98,6 +98,82 @@ fn test_assign_artisan_success() {
 }
 
 #[test]
+#[should_panic(expected = "Assignment has not timed out")]
+fn test_reopen_assignment_just_before_timeout() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_market_id, market_client, registry_id, registry_client) =
+        setup_market_and_registry(&env, admin.clone());
+    let finder = Address::generate(&env);
+    let artisan = Address::generate(&env);
+
+    registry_client.initialize(&admin);
+    seed_artisan_profile(&env, &registry_id, &artisan, 3);
+    let (token_client, token_admin_client) = create_token(&env, &admin);
+    token_admin_client.mint(&finder, &1000);
+
+    let assigned_at = 1_000;
+    env.ledger().with_mut(|li| li.timestamp = assigned_at);
+    let job_id = market_client.create_job(&finder, &token_client.address, &500);
+    market_client.assign_artisan(&finder, &job_id, &artisan);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = assigned_at + ASSIGNMENT_TIMEOUT_SECONDS - 1);
+    market_client.reopen_timed_out_assignment(&finder, &job_id);
+}
+
+#[test]
+fn test_reopen_assignment_after_timeout_preserves_escrow_and_allows_reassignment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (market_id, market_client, registry_id, registry_client) =
+        setup_market_and_registry(&env, admin.clone());
+    let finder = Address::generate(&env);
+    let first_artisan = Address::generate(&env);
+    let second_artisan = Address::generate(&env);
+
+    registry_client.initialize(&admin);
+    seed_artisan_profile(&env, &registry_id, &first_artisan, 3);
+    seed_artisan_profile(&env, &registry_id, &second_artisan, 3);
+    let (token_client, token_admin_client) = create_token(&env, &admin);
+    token_admin_client.mint(&finder, &1000);
+
+    let assigned_at = 1_000;
+    env.ledger().with_mut(|li| li.timestamp = assigned_at);
+    let job_id = market_client.create_job(&finder, &token_client.address, &500);
+    market_client.assign_artisan(&finder, &job_id, &first_artisan);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = assigned_at + ASSIGNMENT_TIMEOUT_SECONDS);
+    market_client.reopen_timed_out_assignment(&finder, &job_id);
+
+    let reopened_job: Job = env.as_contract(&market_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Job(job_id))
+            .unwrap()
+    });
+    assert_eq!(reopened_job.status, JobStatus::Open);
+    assert_eq!(reopened_job.artisan, None);
+    assert_eq!(reopened_job.amount, 500);
+    assert_eq!(token_client.balance(&market_id), 500);
+    assert_eq!(token_client.balance(&finder), 500);
+
+    market_client.assign_artisan(&finder, &job_id, &second_artisan);
+    let reassigned_job: Job = env.as_contract(&market_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Job(job_id))
+            .unwrap()
+    });
+    assert_eq!(reassigned_job.status, JobStatus::Assigned);
+    assert_eq!(reassigned_job.artisan, Some(second_artisan));
+    assert_eq!(token_client.balance(&market_id), 500);
+}
+
+#[test]
 #[should_panic(expected = "Job not found")]
 fn test_assign_artisan_job_not_found() {
     let env = Env::default();


### PR DESCRIPTION
Closes #88 

## Summary

Adds timeout handling for jobs that remain in the `Assigned` state because the selected artisan never starts work.

After seven days, the Finder can reopen the timed-out assignment. The job returns to `Open`, the previous artisan is cleared, and escrow remains safely held by the market contract so another artisan can be assigned.

## Changes

- Records the ledger timestamp when an artisan is assigned.
- Adds a fixed seven-day assignment timeout.
- Adds `reopen_timed_out_assignment`, authorized for the job’s Finder.
- Transitions timed-out jobs from `Assigned` back to `Open`.
- Clears assignment timing data when work starts or an assignment is reopened.
- Emits an `AssignmentTimedOut` event.
- Preserves the job amount and escrow balance during recovery.
- Keeps the recovery flow compatible with future artisan reassignment functionality.

## Testing

Added tests covering:

- Recovery one second before timeout is rejected.
- Recovery at the exact timeout boundary succeeds.
- Job status returns to `Open`.
- Previous artisan is cleared.
- Escrow and Finder balances remain unchanged.
- A new artisan can be assigned after recovery.

All 106 market contract tests pass.

## Recovery outcome

The job is reopened for reassignment rather than cancelled or refunded. Funds remain in escrow until the normal completion, cancellation, or dispute flow resolves them.