### PR TITLE
feat(registry): add blacklist and unblacklist moderation controls

### DIFF
--- a/contracts/market/src/test.rs
+++ b/contracts/market/src/test.rs
@@ -300,6 +300,62 @@ fn test_apply_for_job_blacklisted() {
 }
 
 #[test]
+#[should_panic(expected = "User is blacklisted")]
+fn test_apply_for_job_blocked_after_registry_blacklist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (_market_id, market_client, registry_id, registry_client) =
+        setup_market_and_registry(&env, admin.clone());
+
+    let finder = Address::generate(&env);
+    let artisan = Address::generate(&env);
+
+    registry_client.initialize(&admin);
+    seed_artisan_profile(&env, &registry_id, &artisan, 3);
+
+    let (token_client, token_admin_client) = create_token(&env, &admin);
+    token_admin_client.mint(&finder, &1000);
+
+    let job_id = market_client.create_job(&finder, &token_client.address, &500);
+
+    registry_client.blacklist_user(&admin, &artisan);
+
+    market_client.apply_for_job(&artisan, &job_id);
+}
+
+#[test]
+fn test_apply_for_job_allowed_after_registry_unblacklist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (market_id, market_client, registry_id, registry_client) =
+        setup_market_and_registry(&env, admin.clone());
+
+    let finder = Address::generate(&env);
+    let artisan = Address::generate(&env);
+
+    registry_client.initialize(&admin);
+    seed_artisan_profile(&env, &registry_id, &artisan, 3);
+
+    let (token_client, token_admin_client) = create_token(&env, &admin);
+    token_admin_client.mint(&finder, &1000);
+
+    let job_id = market_client.create_job(&finder, &token_client.address, &500);
+
+    registry_client.blacklist_user(&admin, &artisan);
+    registry_client.unblacklist_user(&admin, &artisan);
+
+    market_client.apply_for_job(&artisan, &job_id);
+
+    let events = env.events().all();
+    let market_event_count = events.iter().filter(|e| e.0 == market_id).count();
+    assert!(market_event_count >= 1);
+}
+
+#[test]
 fn test_start_job_success() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -65,6 +65,18 @@ pub struct ApplicationReceived {
 }
 
 #[contractevent]
+pub struct UserBlacklisted {
+    #[topic]
+    pub user: Address,
+}
+
+#[contractevent]
+pub struct UserUnblacklisted {
+    #[topic]
+    pub user: Address,
+}
+
+#[contractevent]
 pub struct AdminTransferred {
     #[topic]
     pub new_admin: Address,
@@ -278,6 +290,48 @@ impl Registry {
         write_verification_status(&env, &artisan, &VerificationStatus::Approved);
 
         UserVerified { artisan }.publish(&env);
+    }
+
+    pub fn blacklist_user(env: Env, admin: Address, user: Address) {
+        admin.require_auth();
+
+        let current_admin = read_admin(&env).expect("Contract not initialized");
+        assert!(admin == current_admin, "Unauthorized caller");
+
+        let mut profile = match read_profile(&env, &user) {
+            Some(p) => p,
+            None => panic!("User not found"),
+        };
+
+        if profile.is_blacklisted {
+            panic!("User is already blacklisted");
+        }
+
+        profile.is_blacklisted = true;
+        write_profile(&env, &user, &profile);
+
+        UserBlacklisted { user }.publish(&env);
+    }
+
+    pub fn unblacklist_user(env: Env, admin: Address, user: Address) {
+        admin.require_auth();
+
+        let current_admin = read_admin(&env).expect("Contract not initialized");
+        assert!(admin == current_admin, "Unauthorized caller");
+
+        let mut profile = match read_profile(&env, &user) {
+            Some(p) => p,
+            None => panic!("User not found"),
+        };
+
+        if !profile.is_blacklisted {
+            panic!("User is not blacklisted");
+        }
+
+        profile.is_blacklisted = false;
+        write_profile(&env, &user, &profile);
+
+        UserUnblacklisted { user }.publish(&env);
     }
 
     pub fn transfer_admin(env: Env, old_admin: Address, new_admin: Address) {

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -26,6 +26,21 @@ fn seed_profile(env: &Env, contract_id: &Address, user: &Address, role: u32) {
     });
 }
 
+fn assert_last_event(env: &Env, contract_id: &Address, name: &str, user: &Address) {
+    let events = env.events().all();
+    let last_event = events.last().expect("No events were emitted!");
+
+    assert_eq!(last_event.0, *contract_id);
+
+    let topics = last_event.1;
+
+    let event_name: Symbol = Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
+    assert_eq!(event_name, Symbol::new(env, name));
+
+    let event_user: Address = Address::try_from_val(env, &topics.get(1).unwrap()).unwrap();
+    assert_eq!(event_user, *user);
+}
+
 fn read_application_status(
     env: &Env,
     contract_id: &Address,
@@ -488,4 +503,272 @@ fn test_transfer_admin_emits_event() {
         registry_event_count >= 1,
         "Expected AdminTransferred event to be emitted"
     );
+}
+
+// ── blacklist / unblacklist tests ────────────────────────────────────────────
+
+#[test]
+fn test_blacklist_user_by_admin() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    client.blacklist_user(&admin, &user);
+    assert_last_event(&env, &contract_id, "user_blacklisted", &user);
+
+    assert!(client.get_profile(&user).is_blacklisted);
+}
+
+#[test]
+fn test_unblacklist_user_by_admin() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+    client.blacklist_user(&admin, &user);
+
+    client.unblacklist_user(&admin, &user);
+    assert_last_event(&env, &contract_id, "user_unblacklisted", &user);
+
+    assert!(!client.get_profile(&user).is_blacklisted);
+}
+
+#[test]
+fn test_blacklist_state_transitions_are_repeatable() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    client.blacklist_user(&admin, &user);
+    client.unblacklist_user(&admin, &user);
+    client.blacklist_user(&admin, &user);
+
+    assert!(client.get_profile(&user).is_blacklisted);
+}
+
+#[test]
+fn test_blacklist_user_preserves_role_and_verification() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let artisan = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    env.as_contract(&contract_id, || {
+        write_profile(
+            &env,
+            &artisan,
+            &Profile {
+                role: ROLE_ARTISAN,
+                metadata_hash: String::from_str(&env, "artisan_metadata"),
+                is_verified: true,
+                is_blacklisted: false,
+            },
+        );
+    });
+
+    client.blacklist_user(&admin, &artisan);
+
+    let profile = client.get_profile(&artisan);
+    assert!(profile.is_blacklisted);
+    assert_eq!(profile.role, ROLE_ARTISAN);
+    assert!(profile.is_verified);
+    assert_eq!(
+        profile.metadata_hash,
+        String::from_str(&env, "artisan_metadata")
+    );
+}
+
+#[test]
+fn test_blacklist_user_does_not_affect_other_users() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user1, ROLE_FINDER);
+    seed_profile(&env, &contract_id, &user2, ROLE_FINDER);
+
+    client.blacklist_user(&admin, &user1);
+
+    assert!(client.get_profile(&user1).is_blacklisted);
+    assert!(!client.get_profile(&user2).is_blacklisted);
+}
+
+#[test]
+fn test_blacklist_user_by_new_admin_after_transfer() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+    client.transfer_admin(&admin, &new_admin);
+
+    client.blacklist_user(&new_admin, &user);
+
+    assert!(client.get_profile(&user).is_blacklisted);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized caller")]
+fn test_blacklist_user_rejects_non_admin_caller() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let curator = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &curator, ROLE_CURATOR);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    client.blacklist_user(&curator, &user);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized caller")]
+fn test_unblacklist_user_rejects_non_admin_caller() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let curator = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &curator, ROLE_CURATOR);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+    client.blacklist_user(&admin, &user);
+
+    client.unblacklist_user(&curator, &user);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized caller")]
+fn test_blacklist_user_rejects_old_admin_after_transfer() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+    client.transfer_admin(&admin, &new_admin);
+
+    client.blacklist_user(&admin, &user);
+}
+
+#[test]
+#[should_panic]
+fn test_blacklist_user_requires_admin_signature() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    env.mock_auths(&[]);
+    client.blacklist_user(&admin, &user);
+}
+
+#[test]
+#[should_panic]
+fn test_unblacklist_user_requires_admin_signature() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+    client.blacklist_user(&admin, &user);
+
+    env.mock_auths(&[]);
+    client.unblacklist_user(&admin, &user);
+}
+
+#[test]
+#[should_panic(expected = "Contract not initialized")]
+fn test_blacklist_user_requires_initialization() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    client.blacklist_user(&admin, &user);
+}
+
+#[test]
+#[should_panic(expected = "User not found")]
+fn test_blacklist_user_panics_for_unregistered_user() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let ghost = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    client.blacklist_user(&admin, &ghost);
+}
+
+#[test]
+#[should_panic(expected = "User not found")]
+fn test_unblacklist_user_panics_for_unregistered_user() {
+    let (env, _contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let ghost = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    client.unblacklist_user(&admin, &ghost);
+}
+
+#[test]
+#[should_panic(expected = "User is already blacklisted")]
+fn test_blacklist_user_twice_fails() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    client.blacklist_user(&admin, &user);
+    client.blacklist_user(&admin, &user);
+}
+
+#[test]
+#[should_panic(expected = "User is not blacklisted")]
+fn test_unblacklist_user_when_not_blacklisted_fails() {
+    let (env, contract_id, client) = setup_env();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+    seed_profile(&env, &contract_id, &user, ROLE_FINDER);
+
+    client.unblacklist_user(&admin, &user);
 }


### PR DESCRIPTION
feat(registry): add blacklist and unblacklist moderation controls
Add admin-only blacklist_user and unblacklist_user entrypoints so
moderation state is changed through contract logic instead of direct
storage writes. Both verify the caller against the stored admin, persist
is_blacklisted, and emit moderation events.

Closes #84